### PR TITLE
Fix unread notifications count in getNotifications method

### DIFF
--- a/src/controller/notification.controller.js
+++ b/src/controller/notification.controller.js
@@ -73,7 +73,6 @@ export const getNotifications = async (req, res, next) => {
     const [notifications, totalItems] = await Promise.all([
       await Notification.find({
         $or: [{ userId }, { userId: null }],
-        read: false,
       })
         .skip(skip)
         .limit(limit)
@@ -84,7 +83,10 @@ export const getNotifications = async (req, res, next) => {
     ]);
 
     // count unread notifications
-    const unreadCount = notifications.length;
+    const unreadCount = await Notification.countDocuments({
+      userId,
+      read: false,
+    });
 
     const totalPages = Math.ceil(totalItems / limit);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications list now displays both read and unread items for your account (and any global notices), improving visibility without extra filtering.
* **Bug Fixes**
  * Unread counter now shows the total number of unread notifications for your account, not just those on the current page.
  * Pagination and total counts remain consistent with your account and global notices, ensuring accurate lists and badges across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->